### PR TITLE
Fix get_current_scaled_txouts() to not exclude the lowest contributor who is over the 0.01 payment threshold

### DIFF
--- a/p2pool/main.py
+++ b/p2pool/main.py
@@ -614,14 +614,15 @@ def main(args, net, datadir_path):
                 total_random = 0
                 random_set = set()
                 for s in sorted(results, key=results.__getitem__):
+                    if results[s] >= trunc:
+                        break
                     total_random += results[s]
                     random_set.add(s)
-                    if total_random >= trunc and results[s] >= trunc:
-                        break
-                winner = math.weighted_choice((script, results[script]) for script in random_set)
-                for script in random_set:
-                    del results[script]
-                results[winner] = total_random
+                if total_random:
+                    winner = math.weighted_choice((script, results[script]) for script in random_set)
+                    for script in random_set:
+                        del results[script]
+                    results[winner] = total_random
             if sum(results.itervalues()) < int(scale):
                 results[math.weighted_choice(results.iteritems())] += int(scale) - sum(results.itervalues())
             return results


### PR DESCRIPTION
If I use /patron_sendmany?total=22 to send 22 BTC to miners, and search for all payments over 1 BTC I see these 3:

 "1FGNrRbpWkqwYz9rWXR8UD2boHVfkLgeQg": 3.65901822
 "1MSMgQEKsANqaXGVALuzPWqNDu46KR5zit": 1.40327269
 "1D547dxKbQ2oo13CaepKPCWQ1uaq2hLcXk": 1.0828257

If I then use /patron_sendmany?total=22/1 to cut off all payments less than 1 BTC and award the rest using a random lottery, I see this:

{"1FGNrRbpWkqwYz9rWXR8UD2boHVfkLgeQg": 3.65901822
 "1MSMgQEKsANqaXGVALuzPWqNDu46KR5zit": 1.40327269
 "13XML7Yq3EYfCrKcbuv539kPYbVPAmmttY": 16.93770909}

Notice that the lowest of the original 3 now gets nothing, and his 1.08 BTC goes to the lottery winner.

This commit fixes the problem, so we end up with the following when sending 22 BTC with a 1 BTC cutoff:

{"1FGNrRbpWkqwYz9rWXR8UD2boHVfkLgeQg": 3.5513195
 "1MSMgQEKsANqaXGVALuzPWqNDu46KR5zit": 1.51578235
 "1CM5KrYZ1SEfqrSmWenenYiBNp7Av7t13V": 15.85010017
 "1D547dxKbQ2oo13CaepKPCWQ1uaq2hLcXk": 1.08279798}

where the original 3 get what they would normally get, and the rest goes to the lottery winner.
