### PR TITLE
Add "per block" to payout

### DIFF
--- a/web-static/index.html
+++ b/web-static/index.html
@@ -104,7 +104,7 @@
         <p>Node uptime: <span id="uptime_days"></span> days Peers: <span id="peers_out"></span> out, <span id="peers_in"></span> in</p>
         <p>Local rate: <span id="local_rate"></span> (<span id="local_doa"></span> DOA) Expected time to share: <span id="time_to_share"></span></p>
         <p>Shares: <span id="shares_total"></span> total (<span id="shares_orphan"></span> orphaned, <span id="shares_dead"></span> dead) Efficiency: <span id="efficiency"></span></p>
-        <p>Payout if a block were found NOW: <span id="payout_amount"></span> <span class="symbol"></span> to <span id="payout_addr"></span>. Expected after mining for 24 hours:  <span id="expected_payout_amount"></span> <span class="symbol"></span></p>
+        <p>Payout if a block were found NOW: <span id="payout_amount"></span> <span class="symbol"></span> to <span id="payout_addr"></span>. Expected after mining for 24 hours:  <span id="expected_payout_amount"></span> <span class="symbol"></span> per block.</p>
         <p>Current block value: <span id="block_value"></span> <span class="symbol"></span> Expected time to block: <span id="time_to_block"></span></p>
         <div id="warnings"></div>
         


### PR DESCRIPTION
Question that is asked from time to time. Most ppl thinks it is total for 24hrs of mining, but it it per block reward after 24hrs.
