### PR TITLE
Abort timed out connections with abortConnection() 

### DIFF
--- a/p2pool/p2p.py
+++ b/p2pool/p2p.py
@@ -80,7 +80,12 @@ class Protocol(p2protocol.Protocol):
     def _connect_timeout(self):
         self.timeout_delayed = None
         print 'Handshake timed out, disconnecting from %s:%i' % self.addr
-        self.transport.loseConnection()
+        if self.transport.abortConnection is not None:
+            # Available since Twisted 11.1
+            self.transport.abortConnection()
+        else:
+            # This doesn't always close timed out connections!
+            self.transport.loseConnection()
     
     def packetReceived(self, command, payload2):
         try:
@@ -101,7 +106,12 @@ class Protocol(p2protocol.Protocol):
     def _timeout(self):
         self.timeout_delayed = None
         print 'Connection timed out, disconnecting from %s:%i' % self.addr
-        self.transport.loseConnection()
+        if self.transport.abortConnection is not None:
+            # Available since Twisted 11.1
+            self.transport.abortConnection()
+        else:
+            # This doesn't always close timed out connections!
+            self.transport.loseConnection()
     
     message_version = pack.ComposedType([
         ('version', pack.IntType(32)),


### PR DESCRIPTION
Timed out connections are not always killed with transport.loseConnection().
Call transport.abortConnection() instead.

http://twistedmatrix.com/documents/12.2.0/core/howto/servers.html

This fixes the memory leaking issues.
