### PR TITLE
Memory usage on Windows fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Windows:
 * Install Python 2.7: http://www.python.org/getit/
 * Install Twisted: http://twistedmatrix.com/trac/wiki/Downloads
 * Install Zope.Interface: http://pypi.python.org/pypi/zope.interface/3.8.0
+* Install python win32 api: http://sourceforge.net/projects/pywin32/files/pywin32/Build%20218/
+* Install python win32 api wmi wrapper: https://pypi.python.org/pypi/WMI/#downloads
 * Unzip the files into C:\Python27\Lib\site-packages
 
 Running P2Pool:
@@ -32,14 +34,14 @@ router. Forward port 9333 to the host running P2Pool.
 Run for additional options.
 
     python run_p2pool.py --help
-    
+
 Donations towards further development:
 -------------------------
     1HNeqi3pJRNvXybNX4FKzZgYJsdTSqJTbk
 
 Official wiki :
 -------------------------
-https://en.bitcoin.it/wiki/P2Pool	
+https://en.bitcoin.it/wiki/P2Pool
 
 Alternate web front end :
 -------------------------

--- a/p2pool/util/memory.py
+++ b/p2pool/util/memory.py
@@ -1,13 +1,19 @@
-import gc
 import os
+import platform
 
 _scale = {'kB': 1024, 'mB': 1024*1024,
     'KB': 1024, 'MB': 1024*1024}
 
 def resident():
-    with open('/proc/%d/status' % os.getpid()) as f:
-        v = f.read()
-    i = v.index('VmRSS:')
-    v = v[i:].split(None, 3)
-    #assert len(v) == 3, v
-    return float(v[1]) * _scale[v[2]]
+    if platform.system() == 'Windows':
+        from wmi import WMI
+        w = WMI('.')
+        result = w.query("SELECT WorkingSet FROM Win32_PerfRawData_PerfProc_Process WHERE IDProcess=%d" % os.getpid())
+        return int(result[0].WorkingSet)
+    else:
+        with open('/proc/%d/status' % os.getpid()) as f:
+            v = f.read()
+        i = v.index('VmRSS:')
+        v = v[i:].split(None, 3)
+        #assert len(v) == 3, v
+        return float(v[1]) * _scale[v[2]]

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import zipfile
 import platform
 
 from distutils.core import setup
+from distutils.sysconfig import get_python_lib
 import py2exe
 
 version = __import__('p2pool').__version__
@@ -15,6 +16,8 @@ if os.path.exists('INITBAK'):
 os.rename(os.path.join('p2pool', '__init__.py'), 'INITBAK')
 try:
     open(os.path.join('p2pool', '__init__.py'), 'wb').write('__version__ = %r%s%sDEBUG = False%s' % (version, os.linesep, os.linesep, os.linesep))
+    mfcdir = get_python_lib() + '\pythonwin\\'
+    mfcfiles = [os.path.join(mfcdir, i) for i in ["mfc90.dll", "mfc90u.dll", "mfcm90.dll", "mfcm90u.dll", "Microsoft.VC90.MFC.manifest"]]
     bundle = 1
     if im64:
         bundle = bundle + 2
@@ -27,14 +30,16 @@ try:
         url='http://p2pool.forre.st/',
         data_files=[
             ('', ['README.md']),
+            ("Microsoft.VC90.MFC", mfcfiles),
             ('web-static', [
                 'web-static/d3.v2.min.js',
+                'web-static/favicon.ico',
                 'web-static/graphs.html',
                 'web-static/index.html',
                 'web-static/share.html',
             ]),
         ],
-        
+
         console=['run_p2pool.py'],
         options=dict(py2exe=dict(
             bundle_files=bundle,
@@ -50,7 +55,7 @@ finally:
 win = '32'
 if im64:
     win = '64'
-    
+
 dir_name = 'p2pool_win' + win + '_' + version
 
 if os.path.exists(dir_name):


### PR DESCRIPTION
Resolves issue #76
Using wmi wrapper for pywin32.

Testing py2exe sucks. If anyone else has a problem with a missing zope
module add an **init**.py to the site-packages\zope directory under the
interface directory and magic will happen.
