### PR TITLE
Fixed missing OpenSSL module error.

### DIFF
--- a/conf/requirements.production.pip
+++ b/conf/requirements.production.pip
@@ -1,2 +1,3 @@
 Twisted>=12.2.0
 argparse>=1.2.1
+pyOpenSSL>=0.13


### PR DESCRIPTION
Fixed missing OpenSSL module error when bitcoind configured with HTTPS.
