### PR TITLE
set share diff target based on address hash rate

### DIFF
--- a/p2pool/work.py
+++ b/p2pool/work.py
@@ -313,7 +313,7 @@ class WorkerBridge(worker_interface.WorkerBridge):
         merkle_link = bitcoin_data.calculate_merkle_link([None] + other_transaction_hashes, 0)
         
         print 'New work for worker %s! Difficulty: %.06f Share difficulty: %.06f (speed %.06f) Total block value: %.6f %s including %i transactions' % (
-            pubkey_hash,
+            bitcoin_data.pubkey_hash_to_address(pubkey_hash, self.node.net.PARENT),
             bitcoin_data.target_to_difficulty(target),
             bitcoin_data.target_to_difficulty(share_info['bits'].target),
             local_addr_rates.get(pubkey_hash, 0),

--- a/p2pool/work.py
+++ b/p2pool/work.py
@@ -179,7 +179,7 @@ class WorkerBridge(worker_interface.WorkerBridge):
     def _estimate_local_hash_rate(self):
         if len(self.recent_shares_ts_work) == 50:
             hash_rate = sum(work for ts, work in self.recent_shares_ts_work[1:])//(self.recent_shares_ts_work[-1][0] - self.recent_shares_ts_work[0][0])
-            if hash_rate:
+            if hash_rate > 0:
                 return hash_rate
         return None
     

--- a/p2pool/work.py
+++ b/p2pool/work.py
@@ -243,9 +243,10 @@ class WorkerBridge(worker_interface.WorkerBridge):
                 else:
                     share_type = previous_share_type
         
+        local_addr_rates = self.get_local_addr_rates()
+        
         if desired_share_target is None:
             desired_share_target = 2**256-1
-            local_addr_rates = self.get_local_addr_rates()
             local_hash_rate = local_addr_rates.get(pubkey_hash, 0)
             if local_hash_rate > 0.0:
                 desired_share_target = min(desired_share_target,
@@ -316,7 +317,7 @@ class WorkerBridge(worker_interface.WorkerBridge):
             bitcoin_data.pubkey_hash_to_address(pubkey_hash, self.node.net.PARENT),
             bitcoin_data.target_to_difficulty(target),
             bitcoin_data.target_to_difficulty(share_info['bits'].target),
-            self.get_local_addr_rates().get(pubkey_hash, 0),
+            local_addr_rates.get(pubkey_hash, 0),
             self.current_work.value['subsidy']*1e-8, self.node.net.PARENT.SYMBOL,
             len(self.current_work.value['transactions']),
         )

--- a/p2pool/work.py
+++ b/p2pool/work.py
@@ -313,11 +313,9 @@ class WorkerBridge(worker_interface.WorkerBridge):
         lp_count = self.new_work_event.times
         merkle_link = bitcoin_data.calculate_merkle_link([None] + other_transaction_hashes, 0)
         
-        print 'New work for worker %s! Difficulty: %.06f Share difficulty: %.06f (speed %.06f) Total block value: %.6f %s including %i transactions' % (
-            bitcoin_data.pubkey_hash_to_address(pubkey_hash, self.node.net.PARENT),
+        print 'New work for worker! Difficulty: %.06f Share difficulty: %.06f Total block value: %.6f %s including %i transactions' % (
             bitcoin_data.target_to_difficulty(target),
             bitcoin_data.target_to_difficulty(share_info['bits'].target),
-            local_addr_rates.get(pubkey_hash, 0),
             self.current_work.value['subsidy']*1e-8, self.node.net.PARENT.SYMBOL,
             len(self.current_work.value['transactions']),
         )

--- a/p2pool/work.py
+++ b/p2pool/work.py
@@ -316,7 +316,7 @@ class WorkerBridge(worker_interface.WorkerBridge):
             bitcoin_data.pubkey_hash_to_address(pubkey_hash, self.node.net.PARENT),
             bitcoin_data.target_to_difficulty(target),
             bitcoin_data.target_to_difficulty(share_info['bits'].target),
-            local_addr_rates.get(pubkey_hash, 0),
+            self.get_local_addr_rates().get(pubkey_hash, 0),
             self.current_work.value['subsidy']*1e-8, self.node.net.PARENT.SYMBOL,
             len(self.current_work.value['transactions']),
         )


### PR DESCRIPTION
Instead of small miners getting assigned share diff targets based on the node's local hash rate, it will use the payment addresses' hash rate. Thus a small miner on a big public node has the same diff target as if they ran their own node instead.

I did not do the same logic for the pseudo share rates, that still calculates based on local node hash rate. I was concerned a large public node would have an unexpected increase in traffic if every miner started sending in a lot more pseudo shares. Perhaps that should also be done? Pseudo share target speed shouldn't be a share per second on a public node, however.

I added address and speed in the log since it won't be the same share_diff for every worker now.
