### PR TITLE
Add minimum pseudoshare_target diff to avoid HWs from DIFF 0 work

### DIFF
--- a/p2pool/work.py
+++ b/p2pool/work.py
@@ -297,7 +297,7 @@ class WorkerBridge(worker_interface.WorkerBridge):
         mm_later = [(dict(aux_work, target=aux_work['target'] if aux_work['target'] != 'p2pool' else share_info['bits'].target), index, hashes) for aux_work, index, hashes in mm_later]
         
         if desired_pseudoshare_target is None:
-            target = 2**256-1
+            target = bitcoin_data.difficulty_to_target(float(1.0 / self.node.net.PARENT.DUMB_SCRYPT_DIFF))
             local_hash_rate = self._estimate_local_hash_rate()
             if local_hash_rate is not None:
                 target = min(target,


### PR DESCRIPTION
minimum pseudoshare_target is 1/DUMB_SCRYPT_DIFF to fix DIFF 0 work errors on gpu alt coin miners
