### PR TITLE
Correct namecoin default config filename and RPC port

### DIFF
--- a/p2pool/bitcoin/networks.py
+++ b/p2pool/bitcoin/networks.py
@@ -63,7 +63,7 @@ nets = dict(
         P2P_PREFIX='f9beb4fe'.decode('hex'),
         P2P_PORT=8334,
         ADDRESS_VERSION=52,
-        RPC_PORT=8332,
+        RPC_PORT=8336,
         RPC_CHECK=defer.inlineCallbacks(lambda bitcoind: defer.returnValue(
             'namecoinaddress' in (yield bitcoind.rpc_help()) and
             not (yield bitcoind.rpc_getinfo())['testnet']
@@ -72,7 +72,7 @@ nets = dict(
         POW_FUNC=data.hash256,
         BLOCK_PERIOD=600, # s
         SYMBOL='NMC',
-        CONF_FILE_FUNC=lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'Namecoin') if platform.system() == 'Windows' else os.path.expanduser('~/Library/Application Support/Namecoin/') if platform.system() == 'Darwin' else os.path.expanduser('~/.namecoin'), 'bitcoin.conf'),
+        CONF_FILE_FUNC=lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'Namecoin') if platform.system() == 'Windows' else os.path.expanduser('~/Library/Application Support/Namecoin/') if platform.system() == 'Darwin' else os.path.expanduser('~/.namecoin'), 'namecoin.conf'),
         BLOCK_EXPLORER_URL_PREFIX='http://explorer.dot-bit.org/b/',
         ADDRESS_EXPLORER_URL_PREFIX='http://explorer.dot-bit.org/a/',
         TX_EXPLORER_URL_PREFIX='http://explorer.dot-bit.org/tx/',
@@ -84,7 +84,7 @@ nets = dict(
         P2P_PREFIX='fabfb5fe'.decode('hex'),
         P2P_PORT=18334,
         ADDRESS_VERSION=111,
-        RPC_PORT=8332,
+        RPC_PORT=18336,
         RPC_CHECK=defer.inlineCallbacks(lambda bitcoind: defer.returnValue(
             'namecoinaddress' in (yield bitcoind.rpc_help()) and
             (yield bitcoind.rpc_getinfo())['testnet']
@@ -93,7 +93,7 @@ nets = dict(
         POW_FUNC=data.hash256,
         BLOCK_PERIOD=600, # s
         SYMBOL='tNMC',
-        CONF_FILE_FUNC=lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'Namecoin') if platform.system() == 'Windows' else os.path.expanduser('~/Library/Application Support/Namecoin/') if platform.system() == 'Darwin' else os.path.expanduser('~/.namecoin'), 'bitcoin.conf'),
+        CONF_FILE_FUNC=lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'Namecoin') if platform.system() == 'Windows' else os.path.expanduser('~/Library/Application Support/Namecoin/') if platform.system() == 'Darwin' else os.path.expanduser('~/.namecoin'), 'namecoin.conf'),
         BLOCK_EXPLORER_URL_PREFIX='http://testnet.explorer.dot-bit.org/b/',
         ADDRESS_EXPLORER_URL_PREFIX='http://testnet.explorer.dot-bit.org/a/',
         TX_EXPLORER_URL_PREFIX='http://testnet.explorer.dot-bit.org/tx/',


### PR DESCRIPTION
There are a couple of inconsistencies between the namecoin defaults in "/bitcoin/networks.py" and the actual behaviour/code of namecoin (current version at least). First, the config file is called "namecoin.conf" not "bitcoin.conf". Second, the default RPC port is 8336 not 8332 which conflicts with bitcoin. Third, the test network entry for namecoin had the same port as the live bitcoin network, when it should actually be 18336. 

Perhaps a really early version of namecoin really had those issues (same filename and RPC port as bitcoin) because I have seen a few questions about that, searching the internet. However if you look at the current namecoin code it is not the case. Either they have corrected them now or always had those unique values. So for the sake of avoiding future confusion and collision with bitcoin defaults, I believe this should be updated now.

This should be a low (perhaps zero) impact change because there is no direct namecoin support in P2Pool anyway, just via bitcoin merged mining. Further, when merged mining you provide the full RPC user, password and port via the "--merged" parameter. So these defaults are mainly for the record. I just want to make sure everything is correct to avoid confusion and make sure any new work we do in this area is with the right values.
