### PR TITLE
Fixed correct direction in message about new established connection.

### DIFF
--- a/p2pool/p2p.py
+++ b/p2pool/p2p.py
@@ -670,8 +670,8 @@ class Node(object):
             raise ValueError('already have peer')
         self.peers[conn.nonce] = conn
         
-        print '%s connection to peer %s:%i established. p2pool version: %i %r' % ('Incoming' if conn.incoming else 'Outgoing', conn.addr[0], conn.addr[1], conn.other_version, conn.other_sub_version)
-    
+        print '%s peer %s:%i established. p2pool version: %i %r' % ('Incoming connection from' if conn.incoming else 'Outgoing connection to', conn.addr[0], conn.addr[1], conn.other_version, conn.other_sub_version)
+        
     def lost_conn(self, conn, reason):
         if conn.nonce not in self.peers:
             raise ValueError('''don't have peer''')


### PR DESCRIPTION
This showing the right direction for a new established connection.

Before there was these message variants:
Incoming connection to peer x.x.x.x
Outgoing connection to peer x.x.x.x

Now it is:
Incoming connection from peer x.x.x.x
Outgoing connection to peer x.x.x.x