### PR TITLE
Removed spaces in front of information messages

### DIFF
--- a/p2pool/main.py
+++ b/p2pool/main.py
@@ -76,7 +76,7 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
     try:
         print 'p2pool (version %s)' % (p2pool.__version__,)
         print
-        
+
         @defer.inlineCallbacks
         def connect_p2p():
             # connect to bitcoind over bitcoin-p2p
@@ -91,57 +91,57 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
             print '    ...success!'
             print
             defer.returnValue(factory)
-        
+
         if args.testnet: # establish p2p connection first if testnet so bitcoind can work without connections
             factory = yield connect_p2p()
-        
+
         # connect to bitcoind over JSON-RPC and do initial getmemorypool
         url = '%s://%s:%i/' % ('https' if args.bitcoind_rpc_ssl else 'http', args.bitcoind_address, args.bitcoind_rpc_port)
         print '''Testing bitcoind RPC connection to '%s' with username '%s'...''' % (url, args.bitcoind_rpc_username)
         bitcoind = jsonrpc.HTTPProxy(url, dict(Authorization='Basic ' + base64.b64encode(args.bitcoind_rpc_username + ':' + args.bitcoind_rpc_password)), timeout=30)
         yield helper.check(bitcoind, net)
         temp_work = yield helper.getwork(bitcoind)
-        
+
         bitcoind_getinfo_var = variable.Variable(None)
         @defer.inlineCallbacks
         def poll_warnings():
             bitcoind_getinfo_var.set((yield deferral.retry('Error while calling getinfo:')(bitcoind.rpc_getinfo)()))
         yield poll_warnings()
         deferral.RobustLoopingCall(poll_warnings).start(20*60)
-        
+
         print '    ...success!'
         print '    Current block hash: %x' % (temp_work['previous_block'],)
         print '    Current block height: %i' % (temp_work['height'] - 1,)
         print
-        
+
         if not args.testnet:
             factory = yield connect_p2p()
-        
+
         print 'Determining payout address...'
         pubkeys = keypool()
         if args.pubkey_hash is None and args.address != 'dynamic':
             address_path = os.path.join(datadir_path, 'cached_payout_address')
-            
+
             if os.path.exists(address_path):
                 with open(address_path, 'rb') as f:
                     address = f.read().strip('\r\n')
                 print '    Loaded cached address: %s...' % (address,)
             else:
                 address = None
-            
+
             if address is not None:
                 res = yield deferral.retry('Error validating cached address:', 5)(lambda: bitcoind.rpc_validateaddress(address))()
                 if not res['isvalid'] or not res['ismine']:
                     print '    Cached address is either invalid or not controlled by local bitcoind!'
                     address = None
-            
+
             if address is None:
                 print '    Getting payout address from bitcoind...'
                 address = yield deferral.retry('Error getting payout address from bitcoind:', 5)(lambda: bitcoind.rpc_getaccountaddress('p2pool'))()
-            
+
             with open(address_path, 'wb') as f:
                 f.write(address)
-            
+
             my_pubkey_hash = bitcoin_data.address_to_pubkey_hash(address, net.PARENT)
             print '    ...success! Payout address:', bitcoin_data.pubkey_hash_to_address(my_pubkey_hash, net.PARENT)
             print
@@ -168,7 +168,7 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
 
             for i in range(len(pubkeys.keys)):
                 print '    ...payout %d: %s' % (i, bitcoin_data.pubkey_hash_to_address(pubkeys.keys[i], net.PARENT),)
-        
+
         print "Loading shares..."
         shares = {}
         known_verified = set()
@@ -180,13 +180,13 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
         ss = p2pool_data.ShareStore(os.path.join(datadir_path, 'shares.'), net, share_cb, known_verified.add)
         print "    ...done loading %i shares (%i verified)!" % (len(shares), len(known_verified))
         print
-        
-        
+
+
         print 'Initializing work...'
-        
+
         node = p2pool_node.Node(factory, bitcoind, shares.values(), known_verified, net)
         yield node.start()
-        
+
         for share_hash in shares:
             if share_hash not in node.tracker.items:
                 ss.forget_share(share_hash)
@@ -195,20 +195,20 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
                 ss.forget_verified_share(share_hash)
         node.tracker.removed.watch(lambda share: ss.forget_share(share.hash))
         node.tracker.verified.removed.watch(lambda share: ss.forget_verified_share(share.hash))
-        
+
         def save_shares():
             for share in node.tracker.get_chain(node.best_share_var.value, min(node.tracker.get_height(node.best_share_var.value), 2*net.CHAIN_LENGTH)):
                 ss.add_share(share)
                 if share.hash in node.tracker.verified.items:
                     ss.add_verified_hash(share.hash)
         deferral.RobustLoopingCall(save_shares).start(60)
-        
+
         print '    ...success!'
         print
-        
-        
+
+
         print 'Joining p2pool network using port %i...' % (args.p2pool_port,)
-        
+
         @defer.inlineCallbacks
         def parse(host):
             port = net.P2P_PORT
@@ -216,7 +216,7 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
                 host, port_str = host.split(':')
                 port = int(port_str)
             defer.returnValue(((yield reactor.resolve(host)), port))
-        
+
         addrs = {}
         if os.path.exists(os.path.join(datadir_path, 'addrs')):
             try:
@@ -231,14 +231,14 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
                     addrs[addr] = (0, time.time(), time.time())
             except:
                 log.err()
-        
+
         connect_addrs = set()
         for addr_df in map(parse, args.p2pool_nodes):
             try:
                 connect_addrs.add((yield addr_df))
             except:
                 log.err()
-        
+
         node.p2p_node = p2pool_node.P2PNode(node,
             port=args.p2pool_port,
             max_incoming_conns=args.p2pool_conns,
@@ -249,15 +249,15 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
             external_ip=args.p2pool_external_ip,
         )
         node.p2p_node.start()
-        
+
         def save_addrs():
             with open(os.path.join(datadir_path, 'addrs'), 'wb') as f:
                 f.write(json.dumps(node.p2p_node.addr_store.items()))
         deferral.RobustLoopingCall(save_addrs).start(60)
-        
+
         print '    ...success!'
         print
-        
+
         if args.upnp:
             @defer.inlineCallbacks
             def upnp_thread():
@@ -274,27 +274,27 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
                             log.err(None, 'UPnP error:')
                     yield deferral.sleep(random.expovariate(1/120))
             upnp_thread()
-        
+
         # start listening for workers with a JSON-RPC server
-        
+
         print 'Listening for workers on %r port %i...' % (worker_endpoint[0], worker_endpoint[1])
-        
+
         wb = work.WorkerBridge(node, my_pubkey_hash, args.donation_percentage, merged_urls, args.worker_fee, args, pubkeys, bitcoind)
         web_root = web.get_web_root(wb, datadir_path, bitcoind_getinfo_var)
         caching_wb = worker_interface.CachingWorkerBridge(wb)
         worker_interface.WorkerInterface(caching_wb).attach_to(web_root, get_handler=lambda request: request.redirect('/static/'))
         web_serverfactory = server.Site(web_root)
-        
+
         serverfactory = switchprotocol.FirstByteSwitchFactory({'{': stratum.StratumServerFactory(caching_wb)}, web_serverfactory)
         deferral.retry('Error binding to worker port:', traceback=False)(reactor.listenTCP)(worker_endpoint[1], serverfactory, interface=worker_endpoint[0])
-        
+
         with open(os.path.join(os.path.join(datadir_path, 'ready_flag')), 'wb') as f:
             pass
-        
+
         print '    ...success!'
         print
-        
-        
+
+
         # done!
         print 'Started successfully!'
         print 'Go to http://127.0.0.1:%i/ to view graphs and statistics!' % (worker_endpoint[1],)
@@ -306,15 +306,15 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
             print '''Donating %.1f%% of work towards P2Pool's development. Thank you!''' % (args.donation_percentage,)
             print 'You can increase this amount with --give-author argument! (or decrease it, if you must)'
         print
-        
-        
+
+
         if hasattr(signal, 'SIGALRM'):
             signal.signal(signal.SIGALRM, lambda signum, frame: reactor.callFromThread(
                 sys.stderr.write, 'Watchdog timer went off at:\n' + ''.join(traceback.format_stack())
             ))
             signal.siginterrupt(signal.SIGALRM, False)
             deferral.RobustLoopingCall(signal.alarm, 30).start(1)
-        
+
         if args.irc_announce:
             from twisted.words.protocols import irc
             class IRCClient(irc.IRCClient):
@@ -358,7 +358,7 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
             class IRCClientFactory(protocol.ReconnectingClientFactory):
                 protocol = IRCClient
             reactor.connectTCP("irc.freenode.net", 6667, IRCClientFactory(), bindAddress=(worker_endpoint[0], 0))
-        
+
         @defer.inlineCallbacks
         def status_thread():
             last_str = None
@@ -374,22 +374,22 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
                         len(node.p2p_node.peers),
                         sum(1 for peer in node.p2p_node.peers.itervalues() if peer.incoming),
                     ) + (' FDs: %i R/%i W' % (len(reactor.getReaders()), len(reactor.getWriters())) if p2pool.DEBUG else '')
-                    
+
                     datums, dt = wb.local_rate_monitor.get_datums_in_last()
                     my_att_s = sum(datum['work']/dt for datum in datums)
                     my_shares_per_s = sum(datum['work']/dt/bitcoin_data.target_to_average_attempts(datum['share_target']) for datum in datums)
-                    this_str += '\n Local: %sH/s in last %s Local dead on arrival: %s Expected time to share: %s' % (
+                    this_str += '\nLocal: %sH/s in last %s Local dead on arrival: %s Expected time to share: %s' % (
                         math.format(int(my_att_s)),
                         math.format_dt(dt),
                         math.format_binomial_conf(sum(1 for datum in datums if datum['dead']), len(datums), 0.95),
                         math.format_dt(1/my_shares_per_s) if my_shares_per_s else '???',
                     )
-                    
+
                     if height > 2:
                         (stale_orphan_shares, stale_doa_shares), shares, _ = wb.get_stale_counts()
                         stale_prop = p2pool_data.get_average_stale_prop(node.tracker, node.best_share_var.value, min(60*60//net.SHARE_PERIOD, height))
                         real_att_s = p2pool_data.get_pool_attempts_per_second(node.tracker, node.best_share_var.value, min(height - 1, 60*60//net.SHARE_PERIOD)) / (1 - stale_prop)
-                        
+
                         paystr = ''
                         paytot = 0.0
                         for i in range(len(pubkeys.keys)):
@@ -397,26 +397,26 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
                             paytot += curtot*1e-8
                             paystr += "(%.4f)" % (curtot*1e-8,)
                         paystr += "=%.4f" % (paytot,)
-                        this_str += '\n Shares: %i (%i orphan, %i dead) Stale rate: %s Efficiency: %s Current payout: %s %s' % (
+                        this_str += '\nShares: %i (%i orphan, %i dead) Stale rate: %s Efficiency: %s Current payout: %s %s' % (
                             shares, stale_orphan_shares, stale_doa_shares,
                             math.format_binomial_conf(stale_orphan_shares + stale_doa_shares, shares, 0.95),
                             math.format_binomial_conf(stale_orphan_shares + stale_doa_shares, shares, 0.95, lambda x: (1 - x)/(1 - stale_prop)),
                             paystr, net.PARENT.SYMBOL,
                         )
-                        this_str += '\n Pool: %sH/s Stale rate: %.1f%% Expected time to block: %s' % (
+                        this_str += '\nPool: %sH/s Stale rate: %.1f%% Expected time to block: %s' % (
                             math.format(int(real_att_s)),
                             100*stale_prop,
                             math.format_dt(2**256 / node.bitcoind_work.value['bits'].target / real_att_s),
                         )
-                        
+
                         for warning in p2pool_data.get_warnings(node.tracker, node.best_share_var.value, net, bitcoind_getinfo_var.value, node.bitcoind_work.value):
                             print >>sys.stderr, '#'*40
                             print >>sys.stderr, '>>> Warning: ' + warning
                             print >>sys.stderr, '#'*40
-                        
+
                         if gc.garbage:
                             print '%i pieces of uncollectable cyclic garbage! Types: %r' % (len(gc.garbage), map(type, gc.garbage))
-                    
+
                     if this_str != last_str or time.time() > last_time + 15:
                         print this_str
                         last_str = this_str
@@ -433,9 +433,9 @@ def run():
         print "Twisted doesn't have abortConnection! Upgrade to a newer version of Twisted to avoid memory leaks!"
         print 'Pausing for 3 seconds...'
         time.sleep(3)
-    
+
     realnets = dict((name, net) for name, net in networks.nets.iteritems() if '_testnet' not in name)
-    
+
     parser = fixargparse.FixedArgumentParser(description='p2pool (version %s)' % (p2pool.__version__,), fromfile_prefix_chars='@')
     parser.add_argument('--version', action='version', version=p2pool.__version__)
     parser.add_argument('--net',
@@ -477,7 +477,7 @@ def run():
     parser.add_argument('--no-bugreport',
         help='disable submitting caught exceptions to the author',
         action='store_true', default=False, dest='no_bugreport')
-    
+
     p2pool_group = parser.add_argument_group('p2pool interface')
     p2pool_group.add_argument('--p2pool-port', metavar='PORT',
         help='use port PORT to listen for connections (forward this port from your router!) (default: %s)' % ', '.join('%s:%i' % (name, net.P2P_PORT) for name, net in sorted(realnets.items())),
@@ -500,7 +500,7 @@ def run():
     parser.add_argument('--disable-advertise',
         help='''don't advertise local IP address as being available for incoming connections. useful for running a dark node, along with multiple -n ADDR's and --outgoing-conns 0''',
         action='store_false', default=True, dest='advertise_ip')
-    
+
     worker_group = parser.add_argument_group('worker interface')
     worker_group.add_argument('-w', '--worker-port', metavar='PORT or ADDR:PORT',
         help='listen on PORT on interface with ADDR for RPC connections from miners (default: all interfaces, %s)' % ', '.join('%s:%i' % (name, net.WORKER_PORT) for name, net in sorted(realnets.items())),
@@ -508,7 +508,7 @@ def run():
     worker_group.add_argument('-f', '--fee', metavar='FEE_PERCENTAGE',
         help='''charge workers mining to their own bitcoin address (by setting their miner's username to a bitcoin address) this percentage fee to mine on your p2pool instance. Amount displayed at http://127.0.0.1:WORKER_PORT/fee (default: 0)''',
         type=float, action='store', default=0, dest='worker_fee')
-    
+
     bitcoind_group = parser.add_argument_group('bitcoind interface')
     bitcoind_group.add_argument('--bitcoind-config-path', metavar='BITCOIND_CONFIG_PATH',
         help='custom configuration file path (when bitcoind -conf option used)',
@@ -528,26 +528,26 @@ def run():
     bitcoind_group.add_argument(metavar='BITCOIND_RPCUSERPASS',
         help='bitcoind RPC interface username, then password, space-separated (only one being provided will cause the username to default to being empty, and none will cause P2Pool to read them from bitcoin.conf)',
         type=str, action='store', default=[], nargs='*', dest='bitcoind_rpc_userpass')
-    
+
     args = parser.parse_args()
-    
+
     if args.debug:
         p2pool.DEBUG = True
         defer.setDebugging(True)
     else:
         p2pool.DEBUG = False
-    
+
     net_name = args.net_name + ('_testnet' if args.testnet else '')
     net = networks.nets[net_name]
-    
+
     datadir_path = os.path.join((os.path.join(os.path.dirname(sys.argv[0]), 'data') if args.datadir is None else args.datadir), net_name)
     if not os.path.exists(datadir_path):
         os.makedirs(datadir_path)
-    
+
     if len(args.bitcoind_rpc_userpass) > 2:
         parser.error('a maximum of two arguments are allowed')
     args.bitcoind_rpc_username, args.bitcoind_rpc_password = ([None, None] + args.bitcoind_rpc_userpass)[-2:]
-    
+
     if args.bitcoind_rpc_password is None:
         conf_path = args.bitcoind_config_path or net.PARENT.CONF_FILE_FUNC()
         if not os.path.exists(conf_path):
@@ -579,22 +579,22 @@ def run():
             args.bitcoind_rpc_ssl = True
         if args.bitcoind_rpc_password is None:
             parser.error('''Bitcoin configuration file didn't contain an rpcpassword= line! Add one!''')
-    
+
     if args.bitcoind_rpc_username is None:
         args.bitcoind_rpc_username = ''
-    
+
     if args.bitcoind_rpc_port is None:
         args.bitcoind_rpc_port = net.PARENT.RPC_PORT
-    
+
     if args.bitcoind_p2p_port is None:
         args.bitcoind_p2p_port = net.PARENT.P2P_PORT
-    
+
     if args.p2pool_port is None:
         args.p2pool_port = net.P2P_PORT
-    
+
     if args.p2pool_outgoing_conns > 10:
         parser.error('''--outgoing-conns can't be more than 10''')
-    
+
     if args.worker_endpoint is None:
         worker_endpoint = '', net.WORKER_PORT
     elif ':' not in args.worker_endpoint:
@@ -602,7 +602,7 @@ def run():
     else:
         addr, port = args.worker_endpoint.rsplit(':', 1)
         worker_endpoint = addr, int(port)
-    
+
     if args.address is not None and args.address != 'dynamic':
         try:
             args.pubkey_hash = bitcoin_data.address_to_pubkey_hash(args.address, net.PARENT)
@@ -610,7 +610,7 @@ def run():
             parser.error('error parsing address: ' + repr(e))
     else:
         args.pubkey_hash = None
-    
+
     def separate_url(url):
         s = urlparse.urlsplit(url)
         if '@' not in s.netloc:
@@ -618,10 +618,10 @@ def run():
         userpass, new_netloc = s.netloc.rsplit('@', 1)
         return urlparse.urlunsplit(s._replace(netloc=new_netloc)), userpass
     merged_urls = map(separate_url, args.merged_urls)
-    
+
     if args.logfile is None:
         args.logfile = os.path.join(datadir_path, 'log')
-    
+
     logfile = logging.LogFile(args.logfile)
     pipe = logging.TimestampingPipe(logging.TeePipe([logging.EncodeReplacerPipe(sys.stderr), logfile]))
     sys.stdout = logging.AbortPipe(pipe)
@@ -633,25 +633,25 @@ def run():
             print '...and reopened %r after catching SIGUSR1.' % (args.logfile,)
         signal.signal(signal.SIGUSR1, sigusr1)
     deferral.RobustLoopingCall(logfile.reopen).start(5)
-    
+
     class ErrorReporter(object):
         def __init__(self):
             self.last_sent = None
-        
+
         def emit(self, eventDict):
             if not eventDict["isError"]:
                 return
-            
+
             if self.last_sent is not None and time.time() < self.last_sent + 5:
                 return
             self.last_sent = time.time()
-            
+
             if 'failure' in eventDict:
                 text = ((eventDict.get('why') or 'Unhandled Error')
                     + '\n' + eventDict['failure'].getTraceback())
             else:
                 text = " ".join([str(m) for m in eventDict["message"]]) + "\n"
-            
+
             from twisted.web import client
             client.getPage(
                 url='http://u.forre.st/p2pool_error.cgi',
@@ -661,6 +661,6 @@ def run():
             ).addBoth(lambda x: None)
     if not args.no_bugreport:
         log.addObserver(ErrorReporter().emit)
-    
+
     reactor.callWhenRunning(main, args, net, datadir_path, merged_urls, worker_endpoint)
     reactor.run()


### PR DESCRIPTION
Removed spaces in front of information messages.

This is a minor change, but something that can be annoying when reading logs.

Before it looked like this:
``
2016-01-15 08:55:53.152966 P2Pool: 17308 shares in chain (17312 verified/17312 total) Peers: 26 (20 incoming)
2016-01-15 08:55:53.152966  Local: 648GH/s in last 10.0 minutes Local dead on arrival: ~4.5% (3-7%) Expected time to share: 2.8 hours
2016-01-15 08:55:53.153079  Shares: 39 (2 orphan, 1 dead) Stale rate: ~7.7% (2-21%) Efficiency: ~116.2% (100-123%) Current payout: (0.0000)=0.0000 BTC
2016-01-15 08:55:53.153190  Pool: 1232TH/s Stale rate: 20.5% Expected time to block: 4.6 days
``

Now it lookes like this:
``
2016-01-15 08:55:53.152966 P2Pool: 17308 shares in chain (17312 verified/17312 total) Peers: 26 (20 incoming)
2016-01-15 08:55:53.152966 Local: 648GH/s in last 10.0 minutes Local dead on arrival: ~4.5% (3-7%) Expected time to share: 2.8 hours
2016-01-15 08:55:53.153079 Shares: 39 (2 orphan, 1 dead) Stale rate: ~7.7% (2-21%) Efficiency: ~116.2% (100-123%) Current payout: (0.0000)=0.0000 BTC
2016-01-15 08:55:53.153190 Pool: 1232TH/s Stale rate: 20.5% Expected time to block: 4.6 days
``