### PR TITLE
Don't mine segwit txs for now

### DIFF
--- a/p2pool/bitcoin/helper.py
+++ b/p2pool/bitcoin/helper.py
@@ -55,6 +55,7 @@ def getwork(bitcoind, use_getblocktemplate=False):
         except jsonrpc.Error_for_code(-32601): # Method not found
             print >>sys.stderr, 'Error: Bitcoin version too old! Upgrade to v0.5 or newer!'
             raise deferral.RetrySilentlyException()
+    work['transactions'] = [x for x in work['transactions'] if x['txid'] == x['hash']] # don't mine segwit txs for now
     packed_transactions = [(x['data'] if isinstance(x, dict) else x).decode('hex') for x in work['transactions']]
     if 'height' not in work:
         work['height'] = (yield bitcoind.rpc_getblock(work['previousblockhash']))['height'] + 1


### PR DESCRIPTION
P2Pool will remain fully compatible with Bitcoin even if v17 shares don't activate as long as it doesn't mine segwit txs.